### PR TITLE
Set default font-family to Sans-Serif

### DIFF
--- a/main.css
+++ b/main.css
@@ -3,7 +3,7 @@
 /* ------------- */
 
 * {box-sizing: border-box;}
-body {color: white; background: black;}
+body {color: white; background: black; font-family: sans-serif;}
 h1, h2, h3, p {line-height: 1.35rem; letter-spacing: 0.02rem;}
 h2 {font-size: 2rem; text-align: center; margin: 1rem;}
 p {width: 70%; text-align: center; margin-left: auto; margin-right: auto;}


### PR DESCRIPTION
Eddig mindenki, akinek megmutattam az oldalt a "nincs HTTPS" után azt kérdezte miért ilyen a betűtípus.
Egy egyszerű sans serif oprendszer független, elegáns, és szerintem jól mutat.

# Before

![image](https://user-images.githubusercontent.com/5853972/230796764-9c1b4d32-f0d1-44ab-af29-c9c5bf881889.png)

# After

![image](https://user-images.githubusercontent.com/5853972/230796772-aad7e319-6e12-4aa2-a7f9-0a48277c4d0a.png)

---

_(English transcript)_

Anyone I've showed the site to has complained about the font on the page. Sans serif is an elegant OS agnostic option, and it looks way better in my opinion.
